### PR TITLE
gsuite returns binary NIL instead of atom nil for Bcc

### DIFF
--- a/src/imap.erl
+++ b/src/imap.erl
@@ -949,6 +949,8 @@ tokenize(Data) ->
 
 -spec tokenize(binary(), tokenize_state()) ->
     {[token()], binary(), tokenize_state()}.
+tokenize(Data, {atom, AtomAcc}) ->
+    tokenize(Data, [], pop_token(<<AtomAcc/binary, Data/binary>>));
 tokenize(Data, TokenizeState) ->
     tokenize(Data, [], pop_token(Data, TokenizeState)).
 


### PR DESCRIPTION
gsuite returns `<<"NIL">>` for Bcc while everything else is nil. This was causing case clause errors.